### PR TITLE
I fixed the pictures in profiles, I'm the css wizzard

### DIFF
--- a/app/assets/stylesheets/components/_profile.scss
+++ b/app/assets/stylesheets/components/_profile.scss
@@ -1,8 +1,8 @@
 .profile-photo {
   width: 100%;
-  height: 50vh;
+  height: 54vh;
   background-repeat: no-repeat;
-  background-size: cover;
+  background-size: 100% 100%;
   background-position: center;
 }
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/108656967/188979730-296fd95d-2379-4c2b-a96c-f38388808466.png)
Secret was to use length value with width and height both 100% of parent container instead of cover value for image.